### PR TITLE
Fix: repository url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["eldesh <nephits@gmail.com>"]
 description = "A Rust library providing access to the Linux Media Subsystem."
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/eldesh/linux-media"
+repository = "https://github.com/eldesh/linux-media-rs"
 categories = [
   "api-bindings",
   "os::linux-apis"


### PR DESCRIPTION
Fix repository url that is displayed in crates.io.